### PR TITLE
construct NeptuneCsvInputParser from InputStream

### DIFF
--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParser.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParser.java
@@ -18,7 +18,6 @@ package software.amazon.neptune.csv2rdf;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -86,12 +85,8 @@ public class NeptuneCsvInputParser implements AutoCloseable, Iterator<NeptunePro
 			this.csvParser = setupParser(createInputStreamReader(ins));
 			this.iterator = this.csvParser.iterator();
 			this.header = setupHeader();
-		} catch (FileNotFoundException e) {
-			this.close();
+		} catch (IOException e) {
 			throw new Csv2RdfException("Error creating input stream for CSV file " + file.getAbsolutePath(), e);
-		} catch (Exception e) {
-			this.close();
-			throw e;
 		}
 	}
 
@@ -103,14 +98,9 @@ public class NeptuneCsvInputParser implements AutoCloseable, Iterator<NeptunePro
 	 */
 	public NeptuneCsvInputParser(final InputStream ins) {
 
-		try {
 			this.csvParser = setupParser(createInputStreamReader(ins));
 			this.iterator = this.csvParser.iterator();
 			this.header = setupHeader();
-		} catch (Exception e) {
-			this.close();
-			throw e;
-		}
 	}
 
 	/**

--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParser.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParser.java
@@ -77,6 +77,9 @@ public class NeptuneCsvInputParser implements AutoCloseable, Iterator<NeptunePro
 	 * row as header.
 	 *
 	 * @param file CSV input file
+	 * @throws Csv2RdfException if the file cannot be opened
+	 * @throws Csv2RdfException if the CSV parser cannot be created
+	 * @throws Csv2RdfException if there is no header column in the data
 	 */
 	public NeptuneCsvInputParser(final File file) {
 
@@ -95,6 +98,8 @@ public class NeptuneCsvInputParser implements AutoCloseable, Iterator<NeptunePro
 	 * row as header.
 	 *
 	 * @param ins CSV input stream
+	 * @throws Csv2RdfException if the CSV parser cannot be created
+	 * @throws Csv2RdfException if there is no header column in the data
 	 */
 	public NeptuneCsvInputParser(final InputStream ins) {
 

--- a/src/main/java/software/amazon/neptune/csv2rdf/UriPostTransformation.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/UriPostTransformation.java
@@ -42,7 +42,7 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * <h1>URI Post Transformation</h1>
+ * <h2>URI Post Transformation</h2>
  *
  * URI Post Transformations are used to transform RDF resource IRIs into more
  * readable ones.

--- a/src/test/java/software/amazon/neptune/csv2rdf/Csv2RdfConfigTest.java
+++ b/src/test/java/software/amazon/neptune/csv2rdf/Csv2RdfConfigTest.java
@@ -154,10 +154,10 @@ public class Csv2RdfConfigTest {
 		Exception exception = assertThrows(Csv2RdfException.class,
 				() -> new PropertyGraph2RdfConverter(config.toFile()));
 
-		assertEquals(
-				"Loading configuration failed because of invalid input at uriPostTransformations: Regex is bad. Illegal repetition\n"
-						+ "{sp6}/resource/(\\d+).",
-				exception.getMessage());
+		assertTrue(
+				exception.getMessage().startsWith("Loading configuration failed because of invalid input at uriPostTransformations:")
+				&& exception.getMessage().contains("{sp6}/resource/(\\d+)"),
+				"{sp6}/resource/(\\d+) is an invalid regex and should have caused an exception when parsed");
 	}
 
 	@Test

--- a/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
+++ b/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
@@ -71,6 +73,19 @@ public class NeptuneCsvInputParserTest {
 				() -> new NeptuneCsvInputParser(notExistingFile));
 		assertTrue(exception.getMessage()
 				.matches("Error creating input stream for CSV file .*" + notExistingFile.getPath()));
+	}
+
+	@Test
+	public void openFromInputStream() throws FileNotFoundException {
+
+		File validUtf8 = Paths.get("src", "test", "inputParserTest", "valid-utf8.csv").toFile();
+		FileInputStream ins = new FileInputStream(validUtf8);
+
+		try (NeptuneCsvInputParser parser = new NeptuneCsvInputParser(ins)) {
+			NeptuneCsvUserDefinedProperty property = ((NeptunePropertyGraphVertex) parser.next())
+					.getUserDefinedProperties().get(0);
+			assertEquals("Bärbel", ((NeptuneCsvSetValuedUserDefinedProperty) property).getValues().iterator().next());
+		}
 	}
 
 }


### PR DESCRIPTION
close #1 

Added a new constructor to NeptuneCsvInputParser so that it can construct from an InputStream.
Relaxed a test case assertion that fails in newer JDK (a change in the underlying JDK exception message caused the failure).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
