### PR TITLE
Fixed erroneous handling of escaped semicolons in the ~label column a…

### DIFF
--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParser.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParser.java
@@ -341,9 +341,9 @@ public class NeptuneCsvInputParser implements AutoCloseable, Iterator<NeptunePro
 			return vertex;
 		}
 
-		for (String labelValue : labels.split(NeptuneCsvUserDefinedColumn.ARRAY_VALUE_SEPARATOR)) {
+		for (String labelValue : labels.split("(?<!\\\\)" + NeptuneCsvUserDefinedColumn.ARRAY_VALUE_SEPARATOR)) {
 			if (labelValue != null && !labelValue.isEmpty()) {
-				vertex.add(labelValue);
+				vertex.add(labelValue.replace("\\;",";"));
 			}
 		}
 

--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptunePropertyGraphElement.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptunePropertyGraphElement.java
@@ -304,11 +304,11 @@ public abstract class NeptunePropertyGraphElement {
 		@Override
 		public void add(@NonNull String value) {
 
-			for (String v : value.split(NeptuneCsvUserDefinedColumn.ARRAY_VALUE_SEPARATOR)) {
+			for (String v : value.split("(?<!\\\\)" + NeptuneCsvUserDefinedColumn.ARRAY_VALUE_SEPARATOR)) {
 				if (v == null || v.isEmpty()) {
 					continue;
 				}
-				super.add(v);
+				super.add(v.replace("\\;",";"));
 			}
 		}
 	}

--- a/src/test/inputParserTest/escaped-semicolon.csv
+++ b/src/test/inputParserTest/escaped-semicolon.csv
@@ -1,0 +1,2 @@
+~id,~label,names:String[]
+1,person\;;boss,John\;Smith;Jane\;Smith

--- a/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
+++ b/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Paths;
+import java.util.Collection;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
@@ -85,6 +87,26 @@ public class NeptuneCsvInputParserTest {
 			NeptuneCsvUserDefinedProperty property = ((NeptunePropertyGraphVertex) parser.next())
 					.getUserDefinedProperties().get(0);
 			assertEquals("Bärbel", ((NeptuneCsvSetValuedUserDefinedProperty) property).getValues().iterator().next());
+		}
+	}
+	@Test
+	public void escapedSemicolon() {
+
+		File escapedSemi = Paths.get("src", "test", "inputParserTest", "escaped-semicolon.csv").toFile();
+		try (NeptuneCsvInputParser parser = new NeptuneCsvInputParser(escapedSemi)) {
+
+			NeptunePropertyGraphVertex v = (NeptunePropertyGraphVertex) parser.next();
+			List<NeptuneCsvUserDefinedProperty> props = v.getUserDefinedProperties();
+
+			Collection<String> namesValues = props.get(0).getValues();
+			Collection<String> labels = v.getLabels();
+
+			assertTrue(labels.contains("person;"));
+			assertTrue(labels.contains("boss"));
+			assertEquals(labels.size(), 2);
+			assertEquals(namesValues.size(), 2);
+			assertTrue(namesValues.contains("John;Smith"));
+			assertTrue(namesValues.contains("Jane;Smith"));
 		}
 	}
 


### PR DESCRIPTION
…nd columns of string array type

Fixed an issue where semicolons (;) with a preceding escape character (\;) were interpreted as an array element separator instead of a normal semicolon during CSV parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
