### PR TITLE
Colon in header fix

### DIFF
--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvUserDefinedColumn.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvUserDefinedColumn.java
@@ -286,8 +286,6 @@ public class NeptuneCsvUserDefinedColumn {
 		if (!matcher.matches() || matcher.groupCount() < GROUPS_IN_HEADER_PATTERN) {
 			throw new Csv2RdfException("Invalid column encountered while parsing header: " + trimmed);
 		}
-		System.out.println(matcher.group(0));
-		System.out.println(matcher.group(1));
 
 		String columnName = matcher.group(1);
 		if (columnName.isEmpty()) {

--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvUserDefinedColumn.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvUserDefinedColumn.java
@@ -177,7 +177,7 @@ public class NeptuneCsvUserDefinedColumn {
 	 * data type are separated by a colon. Name and data type consist of
 	 * non-whitespace characters.
 	 */
-	private static final Pattern USER_HEADER_PATTERN = Pattern.compile("^(\\S+?)(:\\S+)?$");
+	private static final Pattern USER_HEADER_PATTERN = Pattern.compile("^(\\S+?)((?<!\\\\):\\S+)?$");
 	private static final int GROUPS_IN_HEADER_PATTERN = 2;
 
 	/**
@@ -286,11 +286,14 @@ public class NeptuneCsvUserDefinedColumn {
 		if (!matcher.matches() || matcher.groupCount() < GROUPS_IN_HEADER_PATTERN) {
 			throw new Csv2RdfException("Invalid column encountered while parsing header: " + trimmed);
 		}
+		System.out.println(matcher.group(0));
+		System.out.println(matcher.group(1));
 
 		String columnName = matcher.group(1);
 		if (columnName.isEmpty()) {
 			throw new Csv2RdfException("Column name is not present for header field: " + trimmed);
 		}
+		columnName = columnName.replace("\\:",":");
 
 		String typeString = matcher.group(2);
 		if (typeString == null || typeString.isEmpty()) {

--- a/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvUserDefinedColumn.java
+++ b/src/main/java/software/amazon/neptune/csv2rdf/NeptuneCsvUserDefinedColumn.java
@@ -175,7 +175,8 @@ public class NeptuneCsvUserDefinedColumn {
 	/**
 	 * A column name consists of two parts: name and optional data type. Name and
 	 * data type are separated by a colon. Name and data type consist of
-	 * non-whitespace characters.
+	 * non-whitespace characters. If a colon appears within the column name,
+	 * it must be escaped by preceding it with a backslash: {@code \:}.
 	 */
 	private static final Pattern USER_HEADER_PATTERN = Pattern.compile("^(\\S+?)((?<!\\\\):\\S+)?$");
 	private static final int GROUPS_IN_HEADER_PATTERN = 2;

--- a/src/test/inputParserTest/colon-in-header.csv
+++ b/src/test/inputParserTest/colon-in-header.csv
@@ -1,2 +1,2 @@
-~id,~label,http\://example.com/age:Int,multi\:backslash\\\:header:String
-1,person,26,"a string"
+~id,~label,http\://example.com/age:Int,multi\:backslash\\\:header:String,noDataType\:,having\back\slashes\:end:Int
+1,person,26,"a string","another string","another string"

--- a/src/test/inputParserTest/colon-in-header.csv
+++ b/src/test/inputParserTest/colon-in-header.csv
@@ -1,0 +1,2 @@
+~id,~label,http\://example.com/age:Int,multi\:backslash\\\:header:String
+1,person,26,"a string"

--- a/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
+++ b/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
@@ -31,6 +31,7 @@ import org.junit.jupiter.api.Test;
 import software.amazon.neptune.csv2rdf.NeptunePropertyGraphElement.NeptuneCsvSetValuedUserDefinedProperty;
 import software.amazon.neptune.csv2rdf.NeptunePropertyGraphElement.NeptuneCsvUserDefinedProperty;
 import software.amazon.neptune.csv2rdf.NeptunePropertyGraphElement.NeptunePropertyGraphVertex;
+import software.amazon.neptune.csv2rdf.NeptuneCsvUserDefinedColumn.DataType;
 
 public class NeptuneCsvInputParserTest {
 
@@ -120,9 +121,23 @@ public class NeptuneCsvInputParserTest {
 			List<NeptuneCsvUserDefinedProperty> props = v.getUserDefinedProperties();
 			String propName1 = props.get(0).getName();
 			String propName2 = props.get(1).getName();
+			String propName3 = props.get(2).getName();
+			String propName4 = props.get(3).getName();
 
-			assertEquals(propName1,"http://example.com/age");
-			assertEquals(propName2,"multi:backslash\\\\:header");
+			DataType dt1 = props.get(0).getDataType();
+			DataType dt2 = props.get(1).getDataType();
+			DataType dt3 = props.get(2).getDataType();
+			DataType dt4 = props.get(3).getDataType();
+
+			assertEquals("http://example.com/age", propName1);
+			assertEquals("multi:backslash\\\\:header", propName2);
+			assertEquals("noDataType:", propName3);
+			assertEquals("having\\back\\slashes:end", propName4);
+
+			assertEquals(DataType.INT, dt1);
+			assertEquals(DataType.STRING, dt2);
+			assertEquals(DataType.STRING, dt3);
+			assertEquals(DataType.INT, dt4);
 		}
 	}
 }

--- a/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
+++ b/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
@@ -24,9 +24,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
+++ b/src/test/java/software/amazon/neptune/csv2rdf/NeptuneCsvInputParserTest.java
@@ -24,7 +24,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -89,6 +91,7 @@ public class NeptuneCsvInputParserTest {
 			assertEquals("Bärbel", ((NeptuneCsvSetValuedUserDefinedProperty) property).getValues().iterator().next());
 		}
 	}
+
 	@Test
 	public void escapedSemicolon() {
 
@@ -110,4 +113,18 @@ public class NeptuneCsvInputParserTest {
 		}
 	}
 
+	@Test
+	public void escapedColonInHeader() {
+		File escapedColon = Paths.get("src", "test", "inputParserTest", "colon-in-header.csv").toFile();
+		try (NeptuneCsvInputParser parser = new NeptuneCsvInputParser(escapedColon)) {
+
+			NeptunePropertyGraphVertex v = (NeptunePropertyGraphVertex) parser.next();
+			List<NeptuneCsvUserDefinedProperty> props = v.getUserDefinedProperties();
+			String propName1 = props.get(0).getName();
+			String propName2 = props.get(1).getName();
+
+			assertEquals(propName1,"http://example.com/age");
+			assertEquals(propName2,"multi:backslash\\\\:header");
+		}
+	}
 }


### PR DESCRIPTION
Fixed incorrect handling of escaped colons in header column names. Column names containing escaped colons (\:) are now handled according to spec (https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load-tutorial-format-gremlin.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
